### PR TITLE
remove compiler warnings

### DIFF
--- a/include/tiny_tuple/detail/invoke.h
+++ b/include/tiny_tuple/detail/invoke.h
@@ -56,14 +56,14 @@ constexpr typename std::enable_if<is_invocable<Fn, V>::value, int>::type call_wi
 template <typename... Ts, int... Is, typename F>
 constexpr void foreach_impl(tiny_tuple::tuple<Ts...>& tup, std::integer_sequence<int, Is...>, F&& fun)
 {
-    int l[] = {call_with_index(std::forward<F>(fun), tiny_tuple::get<Is>(tup), kvasir::mpl::uint_<Is>{})...};
+    int l[] = {call_with_index(std::forward<F>(fun), tiny_tuple::get<Is>(tup), kvasir::mpl::int_<Is>{})...};
     (void)l;
 }
 
 template <typename... Ts, int... Is, typename F>
 constexpr auto foreach_impl(tuple<Ts...> const& tup, std::integer_sequence<int, Is...>, F&& fun)
 {
-    int l[] = {call_with_index(std::forward<F>(fun), tiny_tuple::get<Is>(tup), kvasir::mpl::uint_<Is>{})...};
+    int l[] = {call_with_index(std::forward<F>(fun), tiny_tuple::get<Is>(tup), kvasir::mpl::int_<Is>{})...};
     (void)l;
 }
 

--- a/include/tiny_tuple/detail/tuple.h
+++ b/include/tiny_tuple/detail/tuple.h
@@ -8,12 +8,12 @@ namespace tiny_tuple
 template <typename... Params>
 struct tuple;
 
-template <int I, typename... Ts, typename VT = kvasir::mpl::call<kvasir::mpl::at<kvasir::mpl::uint_<I>>, Ts...>>
+template <int I, typename... Ts, typename VT = kvasir::mpl::call<kvasir::mpl::at<kvasir::mpl::int_<I>>, Ts...>>
 constexpr auto const& get(tuple<Ts...> const& t);
 
-template <int I, typename... Ts, typename VT = kvasir::mpl::call<kvasir::mpl::at<kvasir::mpl::uint_<I>>, Ts...>>
+template <int I, typename... Ts, typename VT = kvasir::mpl::call<kvasir::mpl::at<kvasir::mpl::int_<I>>, Ts...>>
 auto& get(tuple<Ts...>& t);
-template <int I, typename... Ts, typename VT = kvasir::mpl::call<kvasir::mpl::at<kvasir::mpl::uint_<I>>, Ts...>>
+template <int I, typename... Ts, typename VT = kvasir::mpl::call<kvasir::mpl::at<kvasir::mpl::int_<I>>, Ts...>>
 auto&& get(tuple<Ts...>&& t);
 
 namespace detail


### PR DESCRIPTION
Removes compiler warnings generated due to implicit type conversions